### PR TITLE
Changed module name so it's installable with `go install` and `go run`

### DIFF
--- a/spongebob-cli/go.mod
+++ b/spongebob-cli/go.mod
@@ -1,4 +1,4 @@
-module spongebob-cli
+module github.com/overflowy/spongebob-cli/spongebob-cli
 
 go 1.21.5
 


### PR DESCRIPTION
I don't want to clone the repo but to run it directly with `go run github.com/overflowy/spongebob-cli/spongebob-cli@latest` or
`go install github.com/overflowy/spongebob-cli/spongebob-cli@latest` then `spongebob-cli`